### PR TITLE
Remove disabled check for api_endpoint_url

### DIFF
--- a/asset/templates/merchant.html
+++ b/asset/templates/merchant.html
@@ -46,7 +46,7 @@
                             {{key}}
                         </span>
                         <br>
-                        <input ng-disabled="key == 'api_endpoint_url' || key == 'state'" class="form-control" ng-model="merchants[merchant_id][key]" type="text"><br>
+                        <input class="form-control" ng-model="merchants[merchant_id][key]" type="text"><br>
 
                         <br>
                       </div>


### PR DESCRIPTION
When remotely deploying the applictation the url in the api_endpoint_url field is set to e.g. http://merchant-sample-cheapest:5003 and the field is disabled. This url is incorrect as it should probably point to the url where the application is remote deployed but cannot be changed without manually removing the disabled flag from the input field with the web inspector.