### PR TITLE
Show Order Cost in Producer Config

### DIFF
--- a/asset/js/modules/config.js
+++ b/asset/js/modules/config.js
@@ -423,7 +423,7 @@
                 $http({url: $scope.producer_url + "/products/"+ product_uid,
                       dataType: "json",
                       method: "PUT",
-                      data: [ $filter('filter')($scope.producer, {uid:product_uid})[0] ],
+                      data: $filter('filter')($scope.producer, {uid:product_uid})[0],
                       headers: {
                           "Content-Type": "application/json"
                       }

--- a/asset/templates/producer.html
+++ b/asset/templates/producer.html
@@ -51,6 +51,12 @@
                     <br>
                     <input class="form-control" ng-model='producer[$index]["price"]' type="number"><br>
 
+                    <span class="font-bold no-margins">
+                        Fixed Order Cost
+                    </span>
+                    <br>
+                    <input class="form-control" ng-model='producer[$index]["fixed_order_cost"]' type="number"><br>
+
 
                     <br>
                     <button type="button" class="btn btn-xs btn-success" ng-click='updateProduct(product["uid"])'>Update</button>
@@ -97,6 +103,12 @@
                   </span>
                   <br>
                   <input class="form-control" ng-model='new_product.price' type="number"><br>
+
+                  <span class="font-bold no-margins">
+                      Fixed Order Cost
+                  </span>
+                  <br>
+                  <input class="form-control" ng-model='new_product.fixed_order_cost' type="number"><br>
 
 
                   <br>


### PR DESCRIPTION
Add fixed order cost to the product info in the producer section.

![selection_017](https://user-images.githubusercontent.com/7498573/34947448-6c089de6-fa0a-11e7-8a6e-2f9d5a20d07d.png)

This allows to read the cost, change the cost and create a new product with a specific order cost.

API change: An array is no longer used to send a single product with PUT /products/<uid>