### PR TITLE
Use new merchant API route to get the merchant's state

### DIFF
--- a/asset/js/app.js
+++ b/asset/js/app.js
@@ -182,22 +182,29 @@
         }
 
         function getMerchantDetails() {
-            for (var merchantID in merchants) {
-                (function(merchant_id) {
-                    promises.push(
-                        $http.get(merchants[merchant_id]["api_endpoint_url"] + "/settings")
-                        .then(function(response) {
-                            Object.keys(response.data).sort().forEach(function(key) {
-                                if (key != "merchant_id" && key != "merchant_url") {
-                                    merchants[merchant_id][key] = response.data[key];
-                                }
-                            });
-                        })
-                        .catch(function(e) {
-                            console.log("Error during merchant detail retrieval from '" + merchants[merchant_id]["api_endpoint_url"] + "/settings'");
-                        })
-                    )
-                })(merchantID);
+            for (const merchant_id in merchants) {
+                promises.push(
+                    $http.get(merchants[merchant_id]["api_endpoint_url"] + "/settings")
+                    .then(function(response) {
+                        Object.keys(response.data).sort().forEach(function(key) {
+                            if (key !== "merchant_id" && key !== "merchant_url") {
+                                merchants[merchant_id][key] = response.data[key];
+                            }
+                        });
+                    })
+                    .catch(function(e) {
+                        console.log("Error during merchant detail retrieval from '" + merchants[merchant_id]["api_endpoint_url"] + "/settings'");
+                    })
+                );
+                promises.push(
+                $http.get(merchants[merchant_id]["api_endpoint_url"] + "/settings/execution")
+                    .then(function(response) {
+                        merchants[merchant_id]['state'] = response.data['state'];
+                    })
+                    .catch(function(e) {
+                        console.log("Error during merchant detail retrieval from '" + merchants[merchant_id]["api_endpoint_url"] + "/settings/execution'");
+                    })
+                )
             }
         }
 

--- a/asset/js/modules/dashboard.js
+++ b/asset/js/modules/dashboard.js
@@ -134,13 +134,9 @@
              * Helper
              */
             $scope.merchantStatus = function(merchant){
-                if(merchant["state"] == "initialized"){
-                    return "hpanel dashboard-status-div hbgblue";
-                } else if (merchant["state"] == "running") {
+                if (merchant["state"] === "running") {
                     return "hpanel dashboard-status-div hbggreen";
-                } else if (merchant["state"] == "exiting") {
-                    return "hpanel dashboard-status-div hbgyellow";
-                } else if (merchant["state"] == "stopping") {
+                } else if (merchant["state"] === "stopping") {
                     return "hpanel dashboard-status-div hbgorange";
                 } else {
                     return "hpanel dashboard-status-div hbgred";


### PR DESCRIPTION
It is possible to change a merchant's state with a `POST /settings/execution` request.
Previously, the UI got the merchant's state along with other settings with a `GET /settings` request.
To make the API more consistent, the merchant was changed, so that the state must be requested with `GET /settings/execution` instead of `GET /settings`.
With this change, the UI requests both routes to get the settings and the state.

This PR also removes merchant states that are no longer used.