### PR TITLE
Don't overwrite consumer marketplace_url

### DIFF
--- a/asset/js/modules/config.js
+++ b/asset/js/modules/config.js
@@ -187,7 +187,6 @@
                   $http.get($scope.consumer_url + "/setting/")
                       .then(function(response) {
                               $scope.consumer = response.data;
-                              $scope.consumer.marketplace_url     = $scope.marketplace_url;
                               $scope.purchases_per_minute =  ($scope.consumer.amount_of_consumers*$scope.consumer.consumer_per_minute*$scope.consumer.probability_of_buy)/100;
                           });
               };


### PR DESCRIPTION
Previously, the _Marketplace URL_ field was always overwritten by the value specified in the `env.docker.json` file. This, however, can be incorrect. The consumer container needs to use the `http://marketplace` URL to access other Docker services, whereas the management UI needs to use the 
`http://vm-....eaalab.hpi.uni-potsdam.de` URL as specified in the `env.docker.json` file (which you have to overwrite to point to `http://vm-....eaalab.hpi.uni-potsdam.de` URLs).

This PR, therefore, simply removes the incorrect overwrite of the marketplace URL and instead displays the currently set URL as returned by the consumer.

//cc @frederike-ramin @KBorchar 